### PR TITLE
Use cursor return to retrieve inserted ID

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -54,7 +54,7 @@ def execute(sql: str, params: tuple = ()):
     with closing(sqlite3.connect(DB_PATH)) as con:
         cur = con.execute(sql, params)
         con.commit()
-        return cur.rowcount
+        return cur
 
 def fetchone(sql: str, params: tuple = ()):
     with closing(sqlite3.connect(DB_PATH)) as con:

--- a/bot/rss_worker.py
+++ b/bot/rss_worker.py
@@ -108,13 +108,12 @@ def _already_seen(hash_hex: str) -> bool:
     return bool(row)
 
 def _insert_draft(text: str, media_url: Optional[str], source_url: str, hash_hex: str) -> int:
-    execute(
+    cur = execute(
         "INSERT INTO drafts (text, media_url, status, created_at, source_url, hash) "
         "VALUES (?, ?, 'draft', datetime('now'), ?, ?)",
         (text, media_url, source_url, hash_hex),
     )
-    row = fetchone("SELECT last_insert_rowid()")
-    return int(row[0]) if row else 0
+    return int(cur.lastrowid) if cur else 0
 
 async def _notify_admins(bot: Bot, draft_id: int, title: str):
     # Пытаемся взять список админов из таблицы настроек, иначе из ENV ADMIN_ID(ы) через запятую


### PR DESCRIPTION
## Summary
- return cursor from `db.execute` to access execution metadata
- fetch draft ID in `rss_worker` using `cur.lastrowid`

## Testing
- `python -m py_compile bot/db.py bot/rss_worker.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9359705208320964e61bd3dee1a64