### PR TITLE
Return cursor from execute function

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -54,7 +54,7 @@ def execute(sql: str, params: tuple = ()):
     with closing(sqlite3.connect(DB_PATH)) as con:
         cur = con.execute(sql, params)
         con.commit()
-        return cur.rowcount
+        return cur
 
 def fetchone(sql: str, params: tuple = ()):
     with closing(sqlite3.connect(DB_PATH)) as con:


### PR DESCRIPTION
## Summary
- Make db.execute return the sqlite cursor instead of rowcount while preserving auto-commit and connection closing.
- No call sites required updates as none relied solely on rowcount.

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68b9358cf31483208f2c8f34aa626d20