### PR TITLE
Register admin menu back handler

### DIFF
--- a/bot/handlers/_admin_menu_back.py
+++ b/bot/handlers/_admin_menu_back.py
@@ -1,7 +1,10 @@
 
 # Hotfix: обработчик "⬅️ В меню" из разделов админки
-from aiogram import F
+from aiogram import F, Router
 from aiogram.types import InlineKeyboardMarkup, InlineKeyboardButton
+from .menu import _is_admin  # или общий helper
+
+router = Router(name="_admin_menu_back")
 
 def _kb_root_menu() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=[

--- a/bot/main.py
+++ b/bot/main.py
@@ -22,6 +22,7 @@ from .handlers import (
     schedule,
     publish_delete,
     queue,  # список/карточки запланированных: /queue, кнопки
+    _admin_menu_back,
 )
 
 
@@ -62,6 +63,7 @@ async def main():
     dp.include_router(drafts_archive.router)
     dp.include_router(queue.router)  # /queue и управление слотами
     dp.include_router(admin_panel.router)
+    dp.include_router(_admin_menu_back.router)
 
     # Планировщик публикаций по расписанию
     setup_scheduler(bot)


### PR DESCRIPTION
## Summary
- add Router and `_is_admin` import for back-to-menu handler
- register `_admin_menu_back` router in the main dispatcher

## Testing
- `pip install -r requirements.txt`
- `pytest`
- `python - <<'PY'
from bot.handlers._admin_menu_back import _kb_root_menu
from bot.handlers.menu import inline_main_menu
print(_kb_root_menu().model_dump() == inline_main_menu().model_dump())
PY`

------
https://chatgpt.com/codex/tasks/task_b_68b98f5273f88320894a69fffafac078