### PR TITLE
Add hash field to drafts and initialize before RSS worker

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -44,6 +44,12 @@ def init_db():
                 try: con.execute("ALTER TABLE feed_entries ADD COLUMN hash TEXT")
                 except Exception: pass
 
+        if _table_exists(con, "drafts"):
+            cols = _col_names(con, "drafts")
+            if "hash" not in cols:
+                try: con.execute("ALTER TABLE drafts ADD COLUMN hash TEXT")
+                except Exception: pass
+
         # ---- основная схема ----
         models_path = os.path.join(os.path.dirname(__file__), "models.sql")
         with open(models_path, "r", encoding="utf-8") as f:

--- a/bot/models.sql
+++ b/bot/models.sql
@@ -18,6 +18,7 @@ CREATE TABLE IF NOT EXISTS drafts (
   media_file_id TEXT,                          -- для одиночных медиа
   album_json TEXT,                             -- JSON: [{type:'photo'|'video'|'document', file_id:'...'}]
   buttons_json TEXT,                           -- JSON: [{text:'...', url:'...'}]
+  hash TEXT,                                   -- уникальный хеш черновика
   status TEXT NOT NULL DEFAULT 'draft',        -- draft|queued|published|deleted
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
   published_at TIMESTAMP
@@ -53,6 +54,7 @@ CREATE TABLE IF NOT EXISTS feed_entries (
   title TEXT,
   published_at TIMESTAMP,
   fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+  hash TEXT,
   content_html TEXT,
   content_text TEXT,
   image_url TEXT,
@@ -86,6 +88,7 @@ CREATE TABLE IF NOT EXISTS published_msgs (
 
 CREATE INDEX IF NOT EXISTS idx_entries_feed ON feed_entries(feed_id, published_at DESC);
 CREATE INDEX IF NOT EXISTS idx_drafts_status_created ON drafts(status, created_at DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_drafts_hash ON drafts(hash);
 CREATE INDEX IF NOT EXISTS idx_draft_meta_simhash ON draft_meta(simhash);
 
 -- Уникальность по (feed_id, hash)

--- a/bot/rss_worker.py
+++ b/bot/rss_worker.py
@@ -13,7 +13,7 @@ import httpx
 from aiogram import Bot
 from email.utils import parsedate_to_datetime
 
-from .db import fetchall, fetchone, execute
+from .db import fetchall, fetchone, execute, init_db
 
 log = logging.getLogger(__name__)
 
@@ -261,6 +261,7 @@ def setup_scheduler(scheduler, bot: Bot, interval_sec: Optional[int] = None):
 def setup_rss_worker(bot: Bot, interval_sec: int | None = None) -> AsyncIOScheduler:
     """Создаёт и запускает планировщик, выполняющий ``process_feeds_once``."""
 
+    init_db()
     scheduler = AsyncIOScheduler(timezone=TZ_NAME)
     setup_scheduler(scheduler, bot, interval_sec)
     scheduler.start()


### PR DESCRIPTION
## Summary
- extend drafts table with `hash` field and unique index
- migrate existing databases to include the new column
- run `init_db()` before starting the RSS worker
- include missing `hash` column in `feed_entries` schema for index creation

## Testing
- `python3 -m py_compile bot/db.py bot/rss_worker.py`
- `python3 -m pytest` *(fails: No module named pytest)*
- `DATA_DIR=tmpdata python3 - <<'PY'\nfrom bot.db import init_db\ninit_db()\nprint('init_db ok')\nPY`


------
https://chatgpt.com/codex/tasks/task_b_68b9905fed748320bb20b66ef1b625ed