### PR TITLE
Refactor RSS draft insertion

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -44,6 +44,15 @@ def init_db():
                 try: con.execute("ALTER TABLE feed_entries ADD COLUMN hash TEXT")
                 except Exception: pass
 
+        if _table_exists(con, "draft_meta"):
+            cols = _col_names(con, "draft_meta")
+            if "hash" not in cols:
+                try: con.execute("ALTER TABLE draft_meta ADD COLUMN hash TEXT")
+                except Exception: pass
+            if "media_url" not in cols:
+                try: con.execute("ALTER TABLE draft_meta ADD COLUMN media_url TEXT")
+                except Exception: pass
+
         # ---- основная схема ----
         models_path = os.path.join(os.path.dirname(__file__), "models.sql")
         with open(models_path, "r", encoding="utf-8") as f:

--- a/bot/models.sql
+++ b/bot/models.sql
@@ -66,6 +66,8 @@ CREATE TABLE IF NOT EXISTS draft_meta (
   feed_id INTEGER,
   entry_id INTEGER,
   source_url TEXT,
+  media_url TEXT,
+  hash TEXT,
   simhash INTEGER,
   ai_model TEXT,
   ai_version TEXT,


### PR DESCRIPTION
## Summary
- Save RSS draft metadata in `draft_meta` with media URL and hash
- Insert drafts with required author, content type and parse mode
- Check duplicates via `draft_meta`

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_b_68b990624c6c8320ac3edded57ff8281