### PR TITLE
Add hash column for feed entries

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -41,6 +41,7 @@ def init_db():
         if _table_exists(con, "feed_entries"):
             cols = _col_names(con, "feed_entries")
             if "hash" not in cols:
+                # используется в уникальном индексе uq_feed_entries_hash
                 try: con.execute("ALTER TABLE feed_entries ADD COLUMN hash TEXT")
                 except Exception: pass
 

--- a/bot/models.sql
+++ b/bot/models.sql
@@ -50,6 +50,7 @@ CREATE TABLE IF NOT EXISTS feed_entries (
   feed_id INTEGER NOT NULL,
   guid TEXT,
   url TEXT,
+  hash TEXT,
   title TEXT,
   published_at TIMESTAMP,
   fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,


### PR DESCRIPTION
## Summary
- add `hash` column to `feed_entries` table
- ensure existing databases add `hash` column during initialization

## Testing
- `pytest -q`
- `DATA_DIR=data python - <<'PY'
from bot.db import init_db
import sqlite3, os
init_db()
con = sqlite3.connect(os.path.join('data','bot.db'))
print(con.execute("PRAGMA table_info(feed_entries)").fetchall())
print(con.execute("PRAGMA index_list(feed_entries)").fetchall())
con.close()
PY`

------
https://chatgpt.com/codex/tasks/task_b_68b9906404148320b7ed8004c1aeb241