### PR TITLE
Fix RSS draft insertion and handle media URLs

### DIFF
--- a/bot/db.py
+++ b/bot/db.py
@@ -50,6 +50,12 @@ def init_db():
             if "hash" not in cols:
                 try: con.execute("ALTER TABLE drafts ADD COLUMN hash TEXT")
                 except Exception: pass
+            if "media_url" not in cols:
+                try: con.execute("ALTER TABLE drafts ADD COLUMN media_url TEXT")
+                except Exception: pass
+            if "source_url" not in cols:
+                try: con.execute("ALTER TABLE drafts ADD COLUMN source_url TEXT")
+                except Exception: pass
 
         if _table_exists(con, "draft_meta"):
             cols = _col_names(con, "draft_meta")

--- a/bot/models.sql
+++ b/bot/models.sql
@@ -16,8 +16,10 @@ CREATE TABLE IF NOT EXISTS drafts (
   disable_web_page_preview INTEGER DEFAULT 1,  -- 1:true / 0:false
   silent INTEGER DEFAULT 0,                    -- 1:true / 0:false
   media_file_id TEXT,                          -- для одиночных медиа
+  media_url TEXT,                              -- исходный URL медиа (если нет file_id)
   album_json TEXT,                             -- JSON: [{type:'photo'|'video'|'document', file_id:'...'}]
   buttons_json TEXT,                           -- JSON: [{text:'...', url:'...'}]
+  source_url TEXT,                             -- ссылка на оригинал (для RSS)
   hash TEXT,                                   -- уникальный хеш черновика
   status TEXT NOT NULL DEFAULT 'draft',        -- draft|queued|published|deleted
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
@@ -55,7 +57,6 @@ CREATE TABLE IF NOT EXISTS feed_entries (
   title TEXT,
   published_at TIMESTAMP,
   fetched_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
-  hash TEXT,
   content_html TEXT,
   content_text TEXT,
   image_url TEXT,

--- a/bot/rss_worker.py
+++ b/bot/rss_worker.py
@@ -116,10 +116,11 @@ def _already_seen(hash_hex: str) -> bool:
     return bool(row)
 
 def _insert_draft(text: str, media_url: Optional[str], source_url: str, hash_hex: str) -> int:
+    content_type = "photo" if media_url else "text"
     cur = execute(
-        "INSERT INTO drafts (text, media_url, status, created_at, source_url, hash) "
-        "VALUES (?, ?, 'draft', datetime('now'), ?, ?)",
-        (text, media_url, source_url, hash_hex),
+        "INSERT INTO drafts (author_id, content_type, text, media_url, source_url, hash, status, created_at) "
+        "VALUES (0, ?, ?, ?, ?, ?, 'draft', datetime('now'))",
+        (content_type, text, media_url, source_url, hash_hex),
     )
     return int(cur.lastrowid) if cur else 0
 


### PR DESCRIPTION
## Summary
- add media_url and source_url columns to drafts schema and migrations
- insert RSS drafts with content_type and author, storing media/source links
- allow scheduler to publish media using URLs and clean feed_entries schema

## Testing
- `python -m py_compile bot/db.py bot/rss_worker.py bot/scheduler.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9953c7df083209d0fb9ccc5462ccf