### PR TITLE
Decode HTML entities in RSS worker text cleaning

### DIFF
--- a/bot/rss_worker.py
+++ b/bot/rss_worker.py
@@ -4,6 +4,7 @@ import logging
 import os
 import re
 import hashlib
+import html
 from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta, timezone
 
@@ -60,8 +61,13 @@ def _parse_date(s: Optional[str]) -> Optional[datetime]:
 def _text_clean(s: str) -> str:
     if not s:
         return ""
-    # Уберем html-теги и лишние пробелы
+    # Уберем html-теги
     s = re.sub(r"<[^>]+>", "", s)
+    # Раскодируем HTML-сущности
+    s = html.unescape(s)
+    # Удалим &nbsp; и другие невидимые символы
+    s = re.sub(r"[\u00A0\u200B-\u200D\uFEFF]", " ", s)
+    # Сжимаем лишние пробелы
     s = re.sub(r"\s+", " ", s, flags=re.M).strip()
     return s
 


### PR DESCRIPTION
## Summary
- Decode HTML entities after stripping tags
- Remove `&nbsp;` and other invisible characters in cleaned text

## Testing
- `pytest`
- `python - <<'PY'
import httpx
from bot.rss_worker import _extract_items
urls = [
    'https://lenta.ru/rss/news',
    'https://habr.com/ru/rss/all/all/?fl=ru',
    'https://www.opennet.ru/opennews/opennews_all_utf.rss'
]
for u in urls:
    try:
        with httpx.Client(follow_redirects=True, timeout=20) as client:
            text = client.get(u).text
        items = _extract_items(text)
        print('Feed', u, 'items', len(items))
        if items:
            it = items[0]
            print('Title:', it['title'])
            print('Summary:', it['summary'][:80])
            print()
    except Exception as e:
        print('Feed', u, 'error', e)
PY`
- `python - <<'PY'
from bot.rss_worker import _text_clean
print(_text_clean('Hello&nbsp;world! &amp; other&nbsp;tests\u200b.'))
PY`


------
https://chatgpt.com/codex/tasks/task_b_68b9992af89083208f29127ced21f982