### PR TITLE
Add AI prompt settings and integrate AI formatting

### DIFF
--- a/bot/handlers/_admin_menu_back.py
+++ b/bot/handlers/_admin_menu_back.py
@@ -10,10 +10,11 @@ def _kb_root_menu() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(inline_keyboard=[
         [InlineKeyboardButton(text="📰 RSS‑каналы", callback_data="admin:rss"),
          InlineKeyboardButton(text="⚙️ Настройки",  callback_data="admin:settings")],
-        [InlineKeyboardButton(text="🗓 Очередь", callback_data="menu:queue"),
-         InlineKeyboardButton(text="📄 Черновики", callback_data="menu:drafts")],
-        [InlineKeyboardButton(text="🗂 Архив", callback_data="menu:archive"),
-         InlineKeyboardButton(text="❓ Справка", callback_data="admin:help")]
+        [InlineKeyboardButton(text="🧠 AI", callback_data="admin:ai"),
+         InlineKeyboardButton(text="🗓 Очередь", callback_data="menu:queue")],
+        [InlineKeyboardButton(text="📄 Черновики", callback_data="menu:drafts"),
+         InlineKeyboardButton(text="🗂 Архив", callback_data="menu:archive")],
+        [InlineKeyboardButton(text="❓ Справка", callback_data="admin:help")]
     ])
 
 @router.callback_query(F.data == "admin:menu")

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ trafilatura>=1.7.0
 beautifulsoup4>=4.12.3
 sumy>=0.11.0
 simhash>=2.1.2
+openai>=1.3.0


### PR DESCRIPTION
## Summary
- add AI management section with prompt editing via FSM in admin panel
- persist AI_PROMPT in settings and use it in RSS worker with OpenAI
- expose AI section in admin menus and depend on openai

## Testing
- `python -m py_compile bot/handlers/admin_panel.py bot/handlers/_admin_menu_back.py bot/rss_worker.py`


------
https://chatgpt.com/codex/tasks/task_b_68b9992be92483208b3a174b1e7441fa